### PR TITLE
Remove wayland and replace fallback-x11 with just x11.

### DIFF
--- a/org.libretrainsim.Libre-TrainSim.json
+++ b/org.libretrainsim.Libre-TrainSim.json
@@ -49,8 +49,7 @@
 		}
 	],
 	"finish-args": [
-		"--socket=fallback-x11",
-		"--socket=wayland",
+		"--socket=x11",
 		"--socket=pulseaudio",
 		"--filesystem=~/.local/share/godot/app_userdata/libre-trainsim",
 		"--device=all",


### PR DESCRIPTION
I'm using wayland on fedora 34 and this game didn't launch until I used FlatSeal to remove the wayland permission.
I do not believe godot supports wayland. It instead runs via xwayland.

EDIT: confirmed godot doesn't support wayland yet https://github.com/godotengine/godot-proposals/issues/990